### PR TITLE
colorScheme agregados al theme

### DIFF
--- a/client/src/theme/colors.js
+++ b/client/src/theme/colors.js
@@ -18,6 +18,46 @@ const colors = {
         claro: '#FFE6C1',
         muy_claro: '#FFF7EA'
     },
+    //colores para usar los colores en schema
+    //brandPrincipal = Rosado
+    //brandSecundario = Celeste
+    //brandTerciario = Amarillo
+    brandPrincipal: {
+        "50": "#FFE5F5",
+        "100": "#FFB8E3",
+        "200": "#FF8AD2",
+        "300": "#FF5CC0",
+        "400": "#FF2EAE",
+        "500": "#FF009D",
+        "600": "#CC007D",
+        "700": "#99005E",
+        "800": "#66003F",
+        "900": "#33001F"
+    },
+    brandSecundario: {
+        "50": "#E9FBFC",
+        "100": "#C1F4F6",
+        "200": "#99ECEF",
+        "300": "#72E5E9",
+        "400": "#4ADEE3",
+        "500": "#22D6DD",
+        "600": "#1BABB1",
+        "700": "#148185",
+        "800": "#0E5658",
+        "900": "#072B2C"
+    },
+    brandTerciario: {
+        "50": "#FFF5E5",
+        "100": "#FFE3B8",
+        "200": "#FFD08A",
+        "300": "#FFBE5C",
+        "400": "#FFAC2E",
+        "500": "#FF9A00",
+        "600": "#CC7B00",
+        "700": "#995C00",
+        "800": "#663D00",
+        "900": "#331F00"
+    }
 }
 
 export default colors


### PR DESCRIPTION
Agregados colores para usar los colores en schema
brandPrincipal = Rosado
brandSecundario = Celeste
brandTerciario = Amarillo

En algunos componentes de chackra solicitan usar un colorScheme, para ello se agregaron los colores mencioandos arriba.

![image](https://user-images.githubusercontent.com/37233058/195454941-da29f243-98bd-4d7b-877d-0c403313197b.png)

